### PR TITLE
fix: Remove checkForDependencies, upgrade github-script to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ env:
   THIRD_PARTY_GIT_AUTHOR_EMAIL: opensource+bot@newrelic.com
   THIRD_PARTY_GIT_AUTHOR_NAME: nr-opensource-bot
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -110,7 +113,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           script: |
@@ -190,7 +193,7 @@ jobs:
             
       - name: Update Release
         id: update_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           script: |

--- a/build.gradle
+++ b/build.gradle
@@ -58,23 +58,7 @@ task cleanUp(type: Delete) {
   }
 }
 
-task checkForDependencies(type: Exec) {
-    environment "JAVAAGENTVERSION", javaAgentVersion
-    def rootProject = projectDir.path
-    def cmdLine = rootProject+'/newrelic-dependencies.sh'
-    workingDir rootProject
-    commandLine  cmdLine
-
-}
-
-task buildIfNeeded {
-   dependsOn checkForDependencies
-   dependsOn jar
-   tasks.findByName('jar').mustRunAfter 'checkForDependencies'
-}
-
 task createModule {
-  dependsOn checkForDependencies
   description = 'Generate project files for a new instrumentation module'
   group = 'New Relic Labs'
   doLast {
@@ -173,7 +157,7 @@ subprojects {
     testImplementation 'com.newrelic.agent.java:newrelic-agent:' + project.javaAgentVersion
   }
 
-  task install(dependsOn: buildIfNeeded, type: Copy) {
+  tasks.register('install', Copy) {
     description = 'Copies compiled jar to the NEW_RELIC_EXTENSIONS_DIR.'
     group  = 'New Relic Labs'
 
@@ -181,10 +165,6 @@ subprojects {
 
     from jar
     into extDir
-  }
-
-  compileJava.doFirst {
-    tasks.findByName('checkForDependencies')
   }
 
   install.doFirst  {


### PR DESCRIPTION
## Summary
- Remove `checkForDependencies` task from root build.gradle (referenced deleted newrelic-dependencies.sh)
- Upgrade `actions/github-script` from v6 to v7 (Node 20 deprecated)
- Replace `GITHUB_TOKEN` with `OPENSOURCE_BOT_TOKEN` where needed
- Add `permissions: contents: write`

## Test plan
- [x] `./gradlew clean build -x test` passes locally